### PR TITLE
Correct server API port declaration for #74

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -10,7 +10,7 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 servers:
-  - url: http://rdfshape.weso.es/api/
+  - url: http://rdfshape.weso.es:8080/api/
     description: RDFShape at WESO
   - url: http://shaclex.herokuapp.com/api/
     description: RDFShape at Heroku


### PR DESCRIPTION
This is to avoid issues such as #74. It's not a perfect solution but will let developers doing integration with this API know which port to use for HTTP calls.