### PR TITLE
Created a URL shortener service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,8 +61,14 @@ lazy val typesafeConfigVersion = "1.3.4"
 lazy val jqueryVersion         = "3.4.1"
 lazy val bootstrapVersion      = "4.3.1"
 
+// Scalaj
+lazy val scalajVersion         = "2.4.2"
+
+// Parsing utils
+lazy val  playVersion    = "2.9.0"
+
 // Compiler plugin dependency versions
-lazy val scalaMacrosVersion   = "2.1.1"
+lazy val scalaMacrosVersion    = "2.1.1"
 
 // Dependency modules
 lazy val catsCore          = "org.typelevel"              %% "cats-core"           % catsVersion
@@ -97,6 +103,9 @@ lazy val any23_core        = "org.apache.any23"           % "apache-any23-core" 
 lazy val any23_api         = "org.apache.any23"           % "apache-any23-api"     % any23Version
 lazy val any23_scraper     = "org.apache.any23.plugins"   % "apache-any23-html-scraper" % "2.2"
 lazy val rdf4j_runtime     = "org.eclipse.rdf4j"          % "rdf4j-runtime"        % rdf4jVersion
+
+lazy val scalaj            ="org.scalaj"                  %% "scalaj-http"         % scalajVersion
+lazy val play             = "com.typesafe.play"           %% "play-json"           % playVersion
 
 lazy val jquery            = "org.webjars"                % "jquery"               % jqueryVersion
 lazy val bootstrap         = "org.webjars"                % "bootstrap"            % bootstrapVersion
@@ -166,8 +175,9 @@ lazy val server = project
       rdf4j_runtime,
       plantuml,
       graphvizJava,
-      // scalaj,
-      utilsTest % Test, 
+      scalaj,
+      play,
+      utilsTest % Test,
       // webJars
       jquery,
       bootstrap

--- a/modules/server/src/main/scala/es/weso/server/ApiHelper.scala
+++ b/modules/server/src/main/scala/es/weso/server/ApiHelper.scala
@@ -2,35 +2,28 @@ package es.weso.server
 
 import java.util.concurrent.Executors
 
-import cats.implicits._
 import cats.data.EitherT
 import cats.effect._
-import results._
-
-import scala.concurrent.ExecutionContext.global
-import es.weso.rdf.PrefixMap
+import cats.implicits._
+import es.weso.rdf.{PrefixMap, RDFReasoner}
 import es.weso.rdf.jena.RDFAsJenaModel
-import es.weso.schema._
-import es.weso.server.Defaults._
-import es.weso.utils.FileUtils
-import es.weso.rdf.RDFReasoner
 import es.weso.rdf.nodes._
+import es.weso.schema._
+import es.weso.schemaInfer._
+import es.weso.server.Defaults._
+import es.weso.server.format._
+import es.weso.server.results._
+import es.weso.shapeMaps.{NodeSelector, ResultShapeMap, ShapeMap}
+import es.weso.uml._
+import es.weso.utils.FileUtils
+import es.weso.utils.IOUtils._
+import es.weso.utils.json.JsonUtilsServer._
 import io.circe._
 import org.http4s._
-import org.log4s.getLogger
-import es.weso.uml._
-import es.weso.schemaInfer._
-import es.weso.server.format._
-import es.weso.shapeMaps.{NodeSelector, ShapeMap}
 import org.http4s.client.{Client, JavaNetClientBuilder}
-import es.weso.shacl.converter.Shacl2ShEx
-import es.weso.shex.converter.ShEx2Shacl
-import es.weso.utils.json.JsonUtilsServer._
-import es.weso.server.Defaults._
-import org.http4s.dsl._
-import scala.util.Try
-import es.weso.utils.IOUtils._
-import es.weso.shapeMaps.ResultShapeMap
+import org.log4s.getLogger
+
+import scala.concurrent.ExecutionContext.global
 
 object ApiHelper {
 
@@ -56,7 +49,7 @@ object ApiHelper {
     Uri.fromString(urlStr).fold(
       fail => {
         logger.info(s"Error parsing $urlStr")
-        IO.raiseError[String](new RuntimeException(s"Error resolving ${urlStr} as URL: ${fail.message}"))
+        IO.raiseError[String](new RuntimeException(s"Error resolving $urlStr as URL: ${fail.message}"))
       },
       uri => {
         // TODO: The following code is unsafe...
@@ -80,7 +73,7 @@ object ApiHelper {
                   base: Option[String]): EitherT[IO, String, Option[String]] =
    optSchema match {
     case None => either2es(None.asRight[String])
-    case Some(schemaStr) => {
+    case Some(schemaStr) =>
       val schemaFormat = optSchemaFormat.getOrElse(Schemas.defaultSchemaFormat)
       val schemaEngine = optSchemaEngine.getOrElse(Schemas.defaultSchemaName)
       // val x: EitherT[IO,String,Schema] = Schemas.fromString(schemaStr, schemaFormat, schemaEngine, base)
@@ -88,8 +81,7 @@ object ApiHelper {
         schema <- Schemas.fromString(schemaStr, schemaFormat, schemaEngine, base)
         result <- schema.convert(optTargetSchemaFormat,optTargetSchemaEngine,base.map(IRI(_)))
       } yield Some(result)
-    }
-  }
+   }
 
   private[server] def validate(rdf: RDFReasoner,
                                dp:DataParam,
@@ -145,7 +137,7 @@ object ApiHelper {
      result <- io2es(validate(rdf,dp,schema,sp,tp, relativeBase))
     } yield result
 
-    result.value.flatMap(_.fold(e => err(e),IO.pure(_)))
+    result.value.flatMap(_.fold(e => err(e),IO.pure))
   }
 
 
@@ -159,7 +151,7 @@ object ApiHelper {
            ): IO[Json] = {
     optQuery match {
       case None => IO(Json.Null)
-      case Some(queryStr) => {
+      case Some(queryStr) =>
         val dataFormat = optDataFormat.getOrElse(defaultDataFormat)
         val base = Some(IRI(FileUtils.currentFolderURL))
         for {
@@ -167,7 +159,6 @@ object ApiHelper {
           rdf <- basicRdf.applyInference(optInference.getOrElse("None"))
           json <- rdf.queryAsJson(queryStr)
         } yield json
-      }
     }
   }
 
@@ -186,7 +177,7 @@ object ApiHelper {
     val schemaFormat = optSchemaFormat.getOrElse(defaultSchemaFormat)
     optNodeSelector match {
       case None => IO.pure(DataExtractResult.fromMsg("DataExtract: Node selector not specified"))
-      case Some(nodeSelector) => {
+      case Some(nodeSelector) =>
         val es: ESIO[(Schema,ResultShapeMap)] = for {
           selector <- either2es(NodeSelector.fromString(nodeSelector, base, rdf.getPrefixMap()))
           eitherResult <- {
@@ -200,9 +191,9 @@ object ApiHelper {
               followOnThreshold = Some(1),
               sortFunction = InferOptions.orderByIRI
             )
-            io2es(SchemaInfer.runInferSchema(rdf, 
-               selector, 
-               engine, 
+            io2es(SchemaInfer.runInferSchema(rdf,
+               selector,
+               engine,
                optLabelName.map(IRI(_)).getOrElse(defaultShapeLabel),
                inferOptions
             ))
@@ -221,7 +212,6 @@ object ApiHelper {
             val (schema, resultShapeMap) = pair
             DataExtractResult.fromExtraction(optData, optDataFormat, schemaFormat.name, engine, schema, resultShapeMap)
           })
-      }
     }
   }
 
@@ -259,7 +249,7 @@ object ApiHelper {
    val schemaFormat = optSchemaFormat.getOrElse(defaultSchemaFormat)
    optNodeSelector match {
      case None => ok_es(Json.Null)
-     case Some(nodeSelector) => {
+     case Some(nodeSelector) =>
        for {
          selector <- either2es(NodeSelector.fromString(nodeSelector, base, rdf.getPrefixMap()))
          eitherResult <- io2es {
@@ -271,10 +261,9 @@ object ApiHelper {
          maybePair <- if (withUml) either2es(Schema2UML.schema2UML(schemaInfer).map(Some(_))) else ok_es(None)
          maybeSvg <- io2es(maybePair match {
            case None => IO.pure(None)
-           case Some(pair) => {
+           case Some(pair) =>
              val (uml,warnings) = pair
              uml.toSVG(options).map(Some(_))
-           }
          })
          str <- io2es(schemaInfer.serialize(schemaFormat.name))
        } yield Json.fromFields(
@@ -289,9 +278,8 @@ object ApiHelper {
                val (uml,warnings) = pair
                Json.fromString(uml.toPlantUML(options)) }
            ) ++
-           maybeField(maybeSvg, "svg", Json.fromString(_))
+           maybeField(maybeSvg, "svg", Json.fromString)
        )
-     }
    }
   }
 
@@ -334,15 +322,15 @@ object ApiHelper {
                              errors: List[String]
                              ) {
     def toJson: Json = Json.fromFields(List(
-      ("schemaName", schemaName.fold(Json.Null)(Json.fromString(_))),
-      ("schemaEngine", schemaEngine.fold(Json.Null)(Json.fromString(_))),
+      ("schemaName", schemaName.fold(Json.Null)(Json.fromString)),
+      ("schemaEngine", schemaEngine.fold(Json.Null)(Json.fromString)),
       ("wellFormed", Json.fromBoolean(wellFormed)),
-      ("shapes", Json.fromValues(shapes.map(Json.fromString(_)))),
+      ("shapes", Json.fromValues(shapes.map(Json.fromString))),
       ("shapesPrefixMap", Json.fromValues(shapesPrefixMap.map(pair => Json.fromFields(List(
         ("prefix", Json.fromString(pair._1)),
         ("uri", Json.fromString(pair._2))
       ))))),
-      ("errors", Json.fromValues(errors.map(Json.fromString(_))))
+      ("errors", Json.fromValues(errors.map(Json.fromString)))
     ))
   }
 
@@ -404,7 +392,7 @@ object ApiHelper {
         ("schemaName", Json.fromString(info.schemaName)),
         ("schemaEngine", Json.fromString(info.schemaEngine)),
         ("wellFormed", Json.fromBoolean(info.isWellFormed)),
-        ("errors", Json.fromValues(info.errors.map(Json.fromString(_)))),
+        ("errors", Json.fromValues(info.errors.map(Json.fromString))),
         ("parsed", Json.fromString("Parsed OK")),
         ("svg", Json.fromString(svg)),
         ("plantUML", Json.fromString(plantuml))

--- a/modules/server/src/main/scala/es/weso/server/EndpointParam.scala
+++ b/modules/server/src/main/scala/es/weso/server/EndpointParam.scala
@@ -1,28 +1,18 @@
 package es.weso.server
 
-import java.net.URI
-
-import cats.Applicative
 import cats.data.EitherT
 import cats.effect._
-import es.weso.html2rdf.HTML2RDF
-import es.weso.rdf.{RDFReader, RDFReasoner}
-import es.weso.rdf.jena.{Endpoint, RDFAsJenaModel}
-import es.weso.rdf.nodes.IRI
-import es.weso.server.Defaults._
-import es.weso.server.helper.DataFormat
+import es.weso.rdf.RDFReader
+import es.weso.rdf.jena.Endpoint
 import io.circe.Json
-import org.log4s.getLogger
 // import scalaj.http._
-import org.http4s.dsl._
-import org.http4s.implicits._
-import es.weso.utils.IOUtils._
-import org.http4s.circe._
-import org.http4s.client.Client
-import cats.effect.ContextShift
-import scala.concurrent.ExecutionContext.global
 import java.util.concurrent.Executors
-import org.http4s.client.JavaNetClientBuilder
+
+import cats.effect.ContextShift
+import es.weso.utils.IOUtils._
+import org.http4s.client.{Client, JavaNetClientBuilder}
+
+import scala.concurrent.ExecutionContext.global
 
 
 case class EndpointInfo(msg: String, status: Option[String] = None) {

--- a/modules/server/src/main/scala/es/weso/server/EndpointService.scala
+++ b/modules/server/src/main/scala/es/weso/server/EndpointService.scala
@@ -1,20 +1,19 @@
 package es.weso.server
+import cats.Applicative
+import cats.data.EitherT
 import cats.effect._
+import cats.implicits._
+import es.weso.server.APIDefinitions._
 import es.weso.server.QueryParams._
 import es.weso.server.{Query => ServerQuery}
-import org.http4s._
-import org.http4s.multipart._
-import cats.data.EitherT
-import cats.implicits._
+import es.weso.utils.IOUtils._
 import io.circe.Json
-import cats.Applicative
-import org.http4s.dsl._
-import org.http4s.implicits._
+import org.http4s._
 import org.http4s.circe._
 import org.http4s.client.Client
-import es.weso.utils.IOUtils._
+import org.http4s.dsl._
+import org.http4s.multipart._
 import org.log4s.getLogger
-import APIDefinitions._
 
 class EndpointService[F[_]:Applicative](blocker: Blocker,
                                         client: Client[F])(implicit F: Effect[F],

--- a/modules/server/src/main/scala/es/weso/server/LinksService.scala
+++ b/modules/server/src/main/scala/es/weso/server/LinksService.scala
@@ -1,45 +1,17 @@
 package es.weso.server
+
 import cats.effect._
-import es.weso.server.QueryParams.UrlParam
 import org.http4s.Uri.uri
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Location
-import scalaj.http.Http
-import play.api.libs.json._
 
 class LinksService[F[_]](blocker: Blocker)(implicit F: Effect[F], cs: ContextShift[F])
   extends Http4sDsl[F] {
 
-  val urlShortenerEndpoint = "https://api-ssl.bitly.com/v4/shorten"
-  val urlShortenerDomain = "bit.ly"
-
   case class RequestData(domain: String, url: String)
 
   val routes: HttpRoutes[F] = HttpRoutes.of[F] {
-
-    // Query URL shortener API
-    case GET -> Root / "links" / "shorten" :?
-      UrlParam(url) =>
-      // Request the shortened URL
-      try {
-        val res = Http(urlShortenerEndpoint).postData(s"""{ "long_url": "$url" }""")
-          .header("Content-Type", "application/json")
-          .header("Accept", "application/json")
-          .header("Authorization", "8e4c5fc54b280e5bc969fc0ef7a0f759317b7c64")
-          .asString
-
-        val jsonRes = Json.parse(res.body)
-
-        // Return the short URL if possible
-        if (res.code >= 200 && res.code < 300 && (jsonRes \ "link").isDefined)
-          Ok(s"""{ "og_link": "$url", "short_link": "${(jsonRes \ "link").as[String]}" }""")
-        else
-          InternalServerError (url)
-      }
-      catch {
-        case e: ArithmeticException => InternalServerError (url)
-      }
 
     // data Info
     case GET -> Root / "links" / "i1" =>

--- a/modules/server/src/main/scala/es/weso/server/LinksService.scala
+++ b/modules/server/src/main/scala/es/weso/server/LinksService.scala
@@ -1,72 +1,90 @@
 package es.weso.server
-
-import org.http4s._
-import org.http4s.dsl.io._
 import cats.effect._
-import org.http4s.headers.Location
+import es.weso.server.QueryParams.UrlParam
 import org.http4s.Uri.uri
+import org.http4s._
 import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.Location
+import scalaj.http.Http
+import play.api.libs.json._
 
 class LinksService[F[_]](blocker: Blocker)(implicit F: Effect[F], cs: ContextShift[F])
   extends Http4sDsl[F] {
 
-  val routes = HttpRoutes.of[F] {
+  val urlShortenerEndpoint = "https://api-ssl.bitly.com/v4/shorten"
+  val urlShortenerDomain = "bit.ly"
+
+  case class RequestData(domain: String, url: String)
+
+  val routes: HttpRoutes[F] = HttpRoutes.of[F] {
+
+    // Query URL shortener API
+    case GET -> Root / "links" / "shorten" :?
+      UrlParam(url) =>
+      // Request the shortened URL
+      try {
+        val res = Http(urlShortenerEndpoint).postData(s"""{ "long_url": "$url" }""")
+          .header("Content-Type", "application/json")
+          .header("Accept", "application/json")
+          .header("Authorization", "8e4c5fc54b280e5bc969fc0ef7a0f759317b7c64")
+          .asString
+
+        val jsonRes = Json.parse(res.body)
+
+        // Return the short URL if possible
+        if (res.code >= 200 && res.code < 300 && (jsonRes \ "link").isDefined)
+          Ok(s"""{ "og_link": "$url", "short_link": "${(jsonRes \ "link").as[String]}" }""")
+        else
+          InternalServerError (url)
+      }
+      catch {
+        case e: ArithmeticException => InternalServerError (url)
+      }
 
     // data Info
-    case GET -> Root / "links" / "i1" => {
+    case GET -> Root / "links" / "i1" =>
       MovedPermanently(Location(uri("""/dataInfo?data=%40prefix%20%3A%20%20%20%20%20%20%3Chttp%3A%2F%2Fexample.org%2F%3E%20.%0A%40prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20.%0A%40prefix%20item%3A%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F04802%2F%3E%20.%0A%40prefix%20dbr%3A%20%20%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20.%0A%40prefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20.%0A%40prefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20.%0A%40prefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.example.org%2Fitem%2F%3E%20.%0A%40prefix%20wd%3A%20%20%20%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2F%3E%20.%0A%40prefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20.%0A%0A%3Aalice%20%20a%20%20%20%20%20%20%20foaf%3APerson%20.%0A%0A%3Abob%20%20%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%20%20%20%221990-07-04%22%5E%5Exsd%3Adate%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Aknows%20%20%20%20%20%20%20%20%20%20%20%3Chttp%3A%2F%2Fexample.org%2Falice%23me%3E%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Atopic_interest%20%20wd%3AQ12418%20.%0A%0A%3Acarol%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%22unknown%22%20.%0A%0Awd%3AQ12418%20%20dcterms%3Acreator%20%20dbr%3ALeonardo_da_Vinci%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22Mona%20Lisa%22%20.%0A%0Ait%3A243FA%20%20dcterms%3Asubject%20%20wd%3AQ12418%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22La%20Joconde%20%C3%A0%20Washington%22%40fr%20.%0A&dataFormat=TURTLE&inference=NONE""")))
-    }
 
     // data conversions
-    case GET -> Root / "links" / "i2" => {
+    case GET -> Root / "links" / "i2" =>
       MovedPermanently(Location(uri("""/dataConversions?data=%40prefix%20%3A%20%20%20%20%20%20%3Chttp%3A%2F%2Fexample.org%2F%3E%20.%0A%40prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20.%0A%40prefix%20item%3A%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F04802%2F%3E%20.%0A%40prefix%20dbr%3A%20%20%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20.%0A%40prefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20.%0A%40prefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20.%0A%40prefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.example.org%2Fitem%2F%3E%20.%0A%40prefix%20wd%3A%20%20%20%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2F%3E%20.%0A%40prefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20.%0A%0A%3Aalice%20%20a%20%20%20%20%20%20%20foaf%3APerson%20.%0A%0A%3Abob%20%20%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%20%20%20%221990-07-04%22%5E%5Exsd%3Adate%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Aknows%20%20%20%20%20%20%20%20%20%20%20%3Chttp%3A%2F%2Fexample.org%2Falice%23me%3E%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Atopic_interest%20%20wd%3AQ12418%20.%0A%0A%3Acarol%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%22unknown%22%20.%0A%0Awd%3AQ12418%20%20dcterms%3Acreator%20%20dbr%3ALeonardo_da_Vinci%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22Mona%20Lisa%22%20.%0A%0Ait%3A243FA%20%20dcterms%3Asubject%20%20wd%3AQ12418%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22La%20Joconde%20%C3%A0%20Washington%22%40fr%20.&amp;dataFormat=TURTLE&amp;targetDataFormat=JSON-LD&amp;inference=NONE""")
       ))
-    }
 
     // schema conversions
-    case GET -> Root / "links" / "i3" => {
+    case GET -> Root / "links" / "i3" =>
       MovedPermanently(Location(uri("/schemaConversions?schema=prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20%0Aprefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20%0Aprefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20%0Aprefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F%3E%20%0Aprefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20%0A%0A%3CUser%3E%20IRI%20%7B%20%0A%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5B%20foaf%3APerson%20%5D%3B%20%0A%20schema%3AbirthDate%20%20%20%20%20xsd%3Adate%3F%20%20%3B%0A%20foaf%3Aknows%20%20%20%20%20%20%20%20%20%20%20%40%3CUser%3E*%20%3B%0A%20foaf%3Atopic_interest%20%20%40%3CTopic%3E%7B0%2C10%7D%0A%7D%0A%0A%3CTopic%3E%20%7B%0A%20%20dcterms%3Atitle%20%20%20xsd%3Astring%20%3B%0A%20%20dcterms%3Acreator%20IRI%20%3B%0A%20%20%5Edcterms%3Asubject%20%40%3CItem%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%7D%0A%0A%3CItem%3E%20%7B%0A%20%20dcterms%3Atitle%20%5B%40en%20%40fr%20%40es%5D%20%3B%0A%7D&amp;schemaFormat=ShExC&amp;&amp;schemaEngine=ShEx&amp;&amp;targetSchemaFormatTURTLE&amp;&amp;targetSchemaEngineShEx")))
-    }
 
     // Shema info
-    case GET -> Root / "links" / "i4" => {
+    case GET -> Root / "links" / "i4" =>
       MovedPermanently(Location(uri("""/schemaInfo?schema=prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20%0Aprefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20%0Aprefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20%0Aprefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F%3E%20%0Aprefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20%0A%0A%3CUser%3E%20IRI%20%7B%20%0A%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5B%20foaf%3APerson%20%5D%3B%20%0A%20schema%3AbirthDate%20%20%20%20%20xsd%3Adate%3F%20%20%3B%0A%20foaf%3Aknows%20%20%20%20%20%20%20%20%20%20%20%40%3CUser%3E*%20%3B%0A%20foaf%3Atopic_interest%20%20%40%3CTopic%3E%7B0%2C10%7D%0A%7D%0A%0A%3CTopic%3E%20%7B%0A%20%20dcterms%3Atitle%20%20%20xsd%3Astring%20%3B%0A%20%20dcterms%3Acreator%20IRI%20%3B%0A%20%20%5Edcterms%3Asubject%20%40%3CItem%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%7D%0A%0A%3CItem%3E%20%7B%0A%20%20dcterms%3Atitle%20%5B%40en%20%40fr%20%40es%5D%20%3B%0A%7D&schemaFormat=ShExC&schemaEngine=ShEx""")))
-    }
 
     // ShEx validation
-    case GET -> Root / "links" / "i5" => {
+    case GET -> Root / "links" / "i5" =>
       MovedPermanently(Location(uri("/validate?data=%40prefix%20%3A%20%20%20%20%20%20%3Chttp%3A%2F%2Fexample.org%2F%3E%20.%0A%40prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20.%0A%40prefix%20item%3A%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F04802%2F%3E%20.%0A%40prefix%20dbr%3A%20%20%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20.%0A%40prefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20.%0A%40prefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20.%0A%40prefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.example.org%2Fitem%2F%3E%20.%0A%40prefix%20wd%3A%20%20%20%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2F%3E%20.%0A%40prefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20.%0A%0A%3Aalice%20%20a%20%20%20%20%20%20%20foaf%3APerson%20.%0A%0A%3Abob%20%20%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%20%20%20%221990-07-04%22%5E%5Exsd%3Adate%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Aknows%20%20%20%20%20%20%20%20%20%20%20%3Aalice%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Atopic_interest%20%20wd%3AQ12418%20.%0A%0A%3Acarol%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%22unknown%22%20.%0A%0Awd%3AQ12418%20%20dcterms%3Acreator%20%20dbr%3ALeonardo_da_Vinci%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22Mona%20Lisa%22%20.%0A%0Ait%3A243FA%20%20dcterms%3Asubject%20%20wd%3AQ12418%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22La%20Joconde%20%C3%A0%20Washington%22%40fr%20.&amp;dataFormat=TURTLE&amp;schema=prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20%0Aprefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20%0Aprefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20%0Aprefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F%3E%20%0Aprefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20%0A%0A%3CUser%3E%20IRI%20%7B%20%0A%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5B%20foaf%3APerson%20%5D%3B%20%0A%20schema%3AbirthDate%20%20%20%20%20xsd%3Adate%3F%20%20%3B%0A%20foaf%3Aknows%20%20%20%20%20%20%20%20%20%20%20%40%3CUser%3E*%20%3B%0A%20foaf%3Atopic_interest%20%20%40%3CTopic%3E%7B0%2C10%7D%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%7D%0A%0A%3CTopic%3E%20%7B%0A%20%20dcterms%3Atitle%20%20%20xsd%3Astring%20%3B%0A%20%20dcterms%3Acreator%20IRI%20%3B%0A%20%20%5Edcterms%3Asubject%20%40%3CItem%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%7D%0A%0A%3CItem%3E%20%7B%0A%20%20dcterms%3Atitle%20%5B%40en%20%40fr%20%40es%5D%20%3B%0A%7D&amp;schemaFormat=ShExC&amp;schemaEngine=ShEx&amp;triggerMode=ShapeMap&amp;schemaEmbedded=false&amp;inference=NONE&amp;activeDataTab=%23dataTextArea&amp;activeSchemaTab=%23schemaTextArea&amp;activeShapeMapTab=%23shapeMapTextArea&amp;&amp;shapeMap=%3Abob%40%3CUser%3E%2C%3Acarol%40%3CUser%3E")))
-    }
 
     // SHACL validation
-    case GET -> Root / "links" / "i6" => {
+    case GET -> Root / "links" / "i6" =>
       MovedPermanently(Location(uri("""/validate?data=%40prefix%20%3A%20%20%20%20%20%20%3Chttp%3A%2F%2Fexample.org%2F%3E%20.%0A%40prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20.%0A%40prefix%20item%3A%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F04802%2F%3E%20.%0A%40prefix%20dbr%3A%20%20%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20.%0A%40prefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20.%0A%40prefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20.%0A%40prefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.example.org%2Fitem%2F%3E%20.%0A%40prefix%20wd%3A%20%20%20%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2F%3E%20.%0A%40prefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20.%0A%0A%3Aalice%20%20a%20%20%20%20%20%20%20foaf%3APerson%20.%0A%0A%3Abob%20%20%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%20%20%20%221990-07-04%22%5E%5Exsd%3Adate%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Aknows%20%20%20%20%20%20%20%20%20%20%20%3Aalice%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Atopic_interest%20%20wd%3AQ12418%20.%0A%0A%3Acarol%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%22unknown%22%20.%0A%0Awd%3AQ12418%20%20dcterms%3Acreator%20%20dbr%3ALeonardo_da_Vinci%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22Mona%20Lisa%22%20.%0A%0Ait%3A243FA%20%20dcterms%3Asubject%20%20wd%3AQ12418%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22La%20Joconde%20%C3%A0%20Washington%22%40fr%20.&dataFormat=TURTLE&schema=prefix%20%3A%20%20%20%20%20%20%20%3Chttp%3A%2F%2Fexample.org%2F%3E%20%0Aprefix%20sh%3A%20%20%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2Fns%2Fshacl%23%3E%20%0Aprefix%20xsd%3A%20%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%0Aprefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%0Aprefix%20foaf%3A%20%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0Aprefix%20rdfs%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23%3E%0Aprefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20%0A%20%20%20%20%20%20%20%20%0A%3CUser%3E%20a%20sh%3ANodeShape%20%3B%0A%20%20%20sh%3AtargetClass%20foaf%3APerson%20%3B%0A%20%20%20sh%3Aproperty%20%5B%0A%20%20%20sh%3Apath%20schema%3AbirthDate%20%3B%20%0A%20%20%20sh%3AmaxCount%201%3B%0A%20%20%20sh%3Adatatype%20xsd%3Adate%20%3B%0A%20%5D%20%3B%0A%20sh%3Aproperty%20%5B%0A%20%20%20%20sh%3Apath%20foaf%3Aknows%20%3B%20%0A%20%20%20%20sh%3Anode%20%3CUser%3E%20%3B%0A%20%20%5D%20%3B%20%20%0A%20sh%3Aproperty%20%5B%0A%20%20%20%20sh%3Apath%20foaf%3Atopic_interest%20%3B%20%0A%20%20%20%20sh%3Anode%20%3CTopic%3E%20%3B%0A%20%20%5D%20%3B%20%20%0A.%0A%0A%3CTopic%3E%20a%20sh%3ANodeShape%20%3B%0A%20%20%20sh%3Aproperty%20%5B%0A%20%20%20sh%3Apath%20dcterms%3Atitle%20%3B%20%0A%20%20%20sh%3AminCount%201%3B%20%20%20%20%20%20%20%20%0A%20%20%20sh%3AmaxCount%201%3B%0A%20%20%20sh%3Adatatype%20xsd%3Astring%20%3B%0A%20%5D%20%3B%0A%20sh%3Aproperty%20%5B%0A%20%20%20%20sh%3Apath%20dcterms%3Acreator%20%3B%20%0A%20%20%20%20sh%3AnodeKind%20sh%3AIRI%20%3B%0A%20%20%5D%20%3B%20%20%0A%20sh%3Aproperty%20%5B%0A%20%20%20%20sh%3Apath%20%5B%20sh%3AinversePath%20dcterms%3Asubject%20%5D%20%20%3B%20%0A%20%20%20%20sh%3Anode%20%3CItem%3E%20%20%20%20%20%20%20%20%0A%20%5D.%0A%0A%0A%3CItem%3E%20a%20sh%3ANodeShape%20%3B%0A%20sh%3Aproperty%20%5B%0A%20%20%20sh%3Apath%20dcterms%3Atitle%20%3B%20%0A%20%20%20sh%3AminCount%201%3B%20%20%20%20%20%20%20%20%0A%20%20%20sh%3AmaxCount%201%3B%0A%20%20%20sh%3AlanguageIn%20(%22en%22%20%22fr%22%20%22es%22)%0A%20%5D%20.&schemaFormat=Turtle&schemaEngine=SHACLex&triggerMode=TargetDecls&schemaEmbedded=false&inference=NONE&activeDataTab=%23dataTextArea&activeSchemaTab=%23schemaTextArea&activeShapeMapTab=%23shapeMapTextArea&&shapeMap=%3Abob%40%3CUser%3E%2C%3Acarol%40%3CUser%3E""")))
-    }
 
     // SPARQL endpoint
-    case GET -> Root / "links" / "i7" => {
+    case GET -> Root / "links" / "i7" =>
       MovedPermanently(Location(uri("/validate?data=&amp;dataFormat=TURTLE&amp;schema=PREFIX%20%3A%20%20%20%20%20%20%20%3Chttp%3A%2F%2Fexample.org%2F%3E%0APREFIX%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%0APREFIX%20xsd%3A%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%0APREFIX%20wdt%3A%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fprop%2Fdirect%2F%3E%0APREFIX%20geo%3A%20%3Chttp%3A%2F%2Fwww.opengis.net%2Font%2Fgeosparql%23%3E%0A%3CPlace%3E%20%7B%0A%20%20wdt%3AP625%20geo%3AwktLiteral%0A%7D%20&amp;schemaFormat=ShExC&amp;schemaEngine=ShEx&amp;triggerMode=ShapeMap&amp;schemaEmbedded=false&amp;inference=NONE&amp;activeDataTab=%23dataEndpoint&amp;activeSchemaTab=%23schemaTextArea&amp;activeShapeMapTab=%23shapeMapTextArea&amp;&amp;shapeMap=%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2FQ99%3E%40%3CPlace%3E&amp;endpoint=https://query.wikidata.org/sparql")))
-    }
 
     // Inference
-    case GET -> Root / "links" / "i8" => {
+    case GET -> Root / "links" / "i8" =>
       MovedPermanently(Location(uri("/validate?data=%40prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20.%0A%40prefix%20%3A%20%20%20%20%20%20%3Chttp%3A%2F%2Fexample.org%2F%3E%20.%0A%40prefix%20item%3A%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F04802%2F%3E%20.%0A%40prefix%20dbr%3A%20%20%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20.%0A%40prefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20.%0A%40prefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20.%0A%40prefix%20rdfs%3A%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23%3E%20.%0A%40prefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.example.org%2Fitem%2F%3E%20.%0A%40prefix%20wd%3A%20%20%20%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2F%3E%20.%0A%40prefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20.%0A%0Ait%3A243FA%20%20dcterms%3Asubject%20%20wd%3AQ12418%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22La%20Joconde%20%C3%A0%20Washington%22%40fr%20.%0A%0A%3Abob%20%20%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%20%20%20%221990-07-04%22%5E%5Exsd%3Adate%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Aknows%20%20%20%20%20%20%20%20%20%20%20%3Aalice%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Atopic_interest%20%20wd%3AQ12418%20.%0A%0A%3Acarol%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%22unknown%22%20.%0A%0Awd%3AQ12418%20%20dcterms%3Acreator%20%20dbr%3ALeonardo_da_Vinci%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22Mona%20Lisa%22%20.%0A%0A%3Aalice%20a%20%3AUser%20.%0A%0A%3AUser%20rdfs%3AsubClassOf%20foaf%3APerson%20.%0A%0A&amp;dataFormat=TURTLE&amp;schema=prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20%0Aprefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20%0Aprefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20%0Aprefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F%3E%20%0Aprefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20%0A%0A%3CUser%3E%20IRI%20EXTRA%20a%20%7B%20%0A%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5B%20foaf%3APerson%20%5D%3B%20%0A%20schema%3AbirthDate%20%20%20%20%20xsd%3Adate%3F%20%20%3B%0A%20foaf%3Aknows%20%20%20%20%20%20%20%20%20%20%20%40%3CUser%3E*%20%3B%0A%20foaf%3Atopic_interest%20%20%40%3CTopic%3E%7B0%2C10%7D%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%7D%0A%0A%3CTopic%3E%20%7B%0A%20%20dcterms%3Atitle%20%20%20xsd%3Astring%20%3B%0A%20%20dcterms%3Acreator%20IRI%20%3B%0A%20%20%5Edcterms%3Asubject%20%40%3CItem%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%7D%0A%0A%3CItem%3E%20%7B%0A%20%20dcterms%3Atitle%20%5B%40en%20%40fr%20%40es%5D%20%3B%0A%7D&amp;schemaFormat=ShExC&amp;schemaEngine=ShEx&amp;triggerMode=ShapeMap&amp;schemaEmbedded=false&amp;inference=RDFS&amp;activeDataTab=%23dataTextArea&amp;activeSchemaTab=%23schemaTextArea&amp;activeShapeMapTab=%23shapeMapTextArea&amp;&amp;shapeMap=%3Abob%40%3CUser%3E%2C%3Acarol%40%3CUser%3E")))
-    }
 
     // SPARQL
-    case GET -> Root / "links" / "i9" => {
+    case GET -> Root / "links" / "i9" =>
       MovedPermanently(Location(uri("""/query?data=%40prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20.%0A%40prefix%20item%3A%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F04802%2F%3E%20.%0A%40prefix%20dbr%3A%20%20%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20.%0A%40prefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20.%0A%40prefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20.%0A%40prefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.example.org%2Fitem%2F%3E%20.%0A%40prefix%20wd%3A%20%20%20%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2F%3E%20.%0A%40prefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20.%0A%0Ait%3A243FA%20%20dcterms%3Asubject%20%20wd%3AQ12418%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22La%20Joconde%20%C3%A0%20Washington%22%40fr%20.%0A%0A%3Chttp%3A%2F%2Fexample.org%2Fbob%23me%3E%0A%20%20%20%20%20%20%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%20%20%20%221990-07-04%22%5E%5Exsd%3Adate%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Aknows%20%20%20%20%20%20%20%20%20%20%20%3Chttp%3A%2F%2Fexample.org%2Falice%23me%3E%20%3B%0A%20%20%20%20%20%20%20%20foaf%3Atopic_interest%20%20wd%3AQ12418%20.%0A%0A%3Chttp%3A%2F%2Fexample.org%2Falice%23me%3E%0A%20%20%20%20%20%20%20%20a%20%20%20%20%20%20%20foaf%3APerson%20.%0A%0A%3Chttp%3A%2F%2Fexample.org%2Fcarol%23me%3E%0A%20%20%20%20%20%20%20%20a%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20foaf%3APerson%20%3B%0A%20%20%20%20%20%20%20%20schema%3AbirthDate%20%20%22unknown%22%20.%0A%0Awd%3AQ12418%20%20dcterms%3Acreator%20%20dbr%3ALeonardo_da_Vinci%20%3B%0A%20%20%20%20%20%20%20%20dcterms%3Atitle%20%20%20%20%22Mona%20Lisa%22%20.%0A&dataFormat=TURTLE&query=prefix%20schema%3A%20%3Chttp%3A%2F%2Fschema.org%2F%3E%20%0Aprefix%20item%3A%20%20%3Chttp%3A%2F%2Fdata.europeana.eu%2Fitem%2F04802%2F%3E%20%0Aprefix%20dbr%3A%20%20%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20%0Aprefix%20xsd%3A%20%20%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23%3E%20%0Aprefix%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%20%0Aprefix%20it%3A%20%20%20%20%3Chttp%3A%2F%2Fdata.example.org%2Fitem%2F%3E%20%0Aprefix%20wd%3A%20%20%20%20%3Chttp%3A%2F%2Fwww.wikidata.org%2Fentity%2F%3E%20%0Aprefix%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20%0A%0Aselect%20%3Fitem%20%3Ftopic%20%3Fperson%20where%20%7B%0A%20%20%3Fperson%20foaf%3Atopic_interest%20%3Ftopic%20.%0A%20%20%3Fitem%20%20%20dcterms%3Asubject%20%3Ftopic%20%0A%7D&&inference=NONE&activeDataTab=%23dataTextArea&activeQueryTab=%23queryTextArea""")))
-    }
 
     // Wikidata
-    case GET -> Root / "links" / "i10" => {
+    case GET -> Root / "links" / "i10" =>
       MovedPermanently(Location(uri("""/load?examples=http://www.validatingrdf.com/examples/wikidata/manifest.json""")))
-    }
 
     // FHIR
-    case GET -> Root / "links" / "i11" => {
+    case GET -> Root / "links" / "i11" =>
       MovedPermanently(Location(uri("""/load?examples=https://raw.githubusercontent.com/BD2KOnFHIR/FHIRDevDays2017/master/shex_examples.json""")))
-    }
   }
 }
 

--- a/modules/server/src/main/scala/es/weso/server/PermalinkService.scala
+++ b/modules/server/src/main/scala/es/weso/server/PermalinkService.scala
@@ -1,0 +1,52 @@
+package es.weso.server
+
+import cats.effect._
+import es.weso.server.APIDefinitions._
+import es.weso.server.QueryParams.UrlParam
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.dsl.Http4sDsl
+import play.api.libs.json.{Json => PJson}
+import scalaj.http.Http
+
+class PermalinkService[F[_]](blocker: Blocker, client: Client[F])(implicit F: Effect[F], cs: ContextShift[F])
+  extends Http4sDsl[F] {
+
+  val urlShortenerEndpoint = "https://api-ssl.bitly.com/v4/shorten"
+
+  case class RequestData(domain: String, url: String)
+
+  val routes: HttpRoutes[F] = HttpRoutes.of[F] {
+
+    // Query URL shortener API
+    case GET -> Root / `api` / "permalink" / "generate" :?
+      UrlParam(url) =>
+      // Request the shortened URL
+      try {
+        val res = Http(urlShortenerEndpoint).postData(s"""{ "long_url": "$url" }""")
+          .header("Content-Type", "application/json")
+          .header("Accept", "application/json")
+          .header("Authorization", "8e4c5fc54b280e5bc969fc0ef7a0f759317b7c64")
+          .asString
+
+        val jsonRes = PJson.parse(res.body)
+
+        // Return the short URL if possible
+        if (res.code >= 200 && res.code < 300 && (jsonRes \ "link").isDefined)
+          Ok(s"${(jsonRes \ "link").as[String]}")
+        else
+          InternalServerError (url)
+      }
+      catch {
+        case e: Exception =>
+          InternalServerError (url)
+      }
+    }
+}
+
+object PermalinkService {
+  def apply[F[_]: Effect: ContextShift](blocker: Blocker, client: Client[F]): PermalinkService[F] =
+    new PermalinkService[F](blocker, client)
+}
+
+

--- a/modules/server/src/main/scala/es/weso/server/QueryParams.scala
+++ b/modules/server/src/main/scala/es/weso/server/QueryParams.scala
@@ -20,6 +20,7 @@ object QueryParams {
   lazy val schemaURL = "schemaURL"
   lazy val schemaFormat = "schemaFormat"
   lazy val shape = "shape"
+  lazy val url = "url"
   object DataParameter extends OptionalQueryParamDecoderMatcher[String](data)
   object OptDataParam extends OptionalQueryParamDecoderMatcher[String](data)
   object OptEndpointParam extends OptionalQueryParamDecoderMatcher[String](endpoint)
@@ -61,6 +62,7 @@ object QueryParams {
   object WdSchemaParam extends QueryParamDecoderMatcher[String]("wdSchema")
   object LanguageParam extends QueryParamDecoderMatcher[String]("language")
   object LabelParam extends QueryParamDecoderMatcher[String]("label")
+  object UrlParam extends QueryParamDecoderMatcher[String](url)
   object LimitParam extends OptionalQueryParamDecoderMatcher[String]("limit")
   object ContinueParam extends OptionalQueryParamDecoderMatcher[String]("continue")
 

--- a/modules/server/src/main/scala/es/weso/server/Server.scala
+++ b/modules/server/src/main/scala/es/weso/server/Server.scala
@@ -1,22 +1,15 @@
 package es.weso.server
-import org.http4s._
-import org.http4s.implicits._
-import org.http4s.server._
-import org.http4s.server.blaze.BlazeServerBuilder
-import org.http4s.server.middleware.{CORS, HSTS, Logger}
-import es.weso.server.utils.Http4sUtils._
-import org.log4s.getLogger
 import cats.effect._
 import cats.implicits._
-import es.weso.quickstart.{HelloWorld, TestRoutes}
 import fs2.Stream
-import javax.net.ssl.SSLContext
+import org.http4s._
 import org.http4s.client.Client
 import org.http4s.client.blaze.BlazeClientBuilder
-import org.http4s.dsl.Http4sDsl
+import org.http4s.implicits._
+import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.server.middleware.{CORS, Logger}
 
 import scala.concurrent.ExecutionContext.global
-import scala.util.Properties.envOrNone
 import scala.concurrent.duration._
 
 object Server {
@@ -31,7 +24,6 @@ object Server {
   } */
 
   def routesService[F[_]: ConcurrentEffect](blocker: Blocker, client: Client[F])(implicit T: Timer[F], C: ContextShift[F]): HttpRoutes[F] =
-//    HelloService[F](blocker).routes <+>
     CORS (
       SchemaService[F](blocker,client).routes <+>
       APIService[F](blocker, client).routes <+>
@@ -39,7 +31,9 @@ object Server {
       ShExService[F](blocker,client).routes <+>
       ShapeMapService[F](blocker,client).routes <+>
       WikidataService[F](blocker, client).routes <+>
-      EndpointService[F](blocker,client).routes
+      EndpointService[F](blocker,client).routes <+>
+      PermalinkService[F](blocker,client).routes
+
     ) <+>
     WebService[F](blocker).routes <+>
     DataWebService[F](blocker, client).routes <+>

--- a/modules/server/src/main/scala/es/weso/server/ShExService.scala
+++ b/modules/server/src/main/scala/es/weso/server/ShExService.scala
@@ -1,13 +1,12 @@
 package es.weso.server
 import cats.effect._
 import es.weso.schema._
+import es.weso.server.APIDefinitions._
 import io.circe._
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.client.Client
 import org.http4s.dsl.Http4sDsl
-import org.log4s.getLogger
-import APIDefinitions._
 
 class ShExService[F[_]:ConcurrentEffect: Timer](blocker: Blocker,
                                                client: Client[F])(implicit cs: ContextShift[F])


### PR DESCRIPTION
This PR targets #117.

I've implemented a new endpoint in the server in `/api/permalink/generate`. It connects to [bit.ly](https://bitly.com/) to generate shortened URLs.

Clients may query this endpoint sending a `GET` request containing a `url` parameter that contains the link to be shortened.

For example, a call to `/api/permalink/generate?url=https://github.com` would return [https://bit.ly/3dnDVGh](https://bit.ly/3dnDVGh)