### PR TITLE
Removed empty strings as .env default values.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 Dockerfile
 .dockerignore
+.env
 
 target
 logs

--- a/.env
+++ b/.env
@@ -1,12 +1,13 @@
 # API key for cutt.ly
-CUTTLY_API_KEY=""
+CUTTLY_API_KEY=
 # Credentials to retrieve the SSL certificate
-KEYSTORE_PASSWORD=""
-KEYMANAGER_PASSWORD=""
-KEYSTORE_PATH=""
+KEYSTORE_PASSWORD=
+KEYMANAGER_PASSWORD=
+KEYSTORE_PATH=
 # Credentials to access rdfshape DB on mongo db atlas
-MONGO_DATABASE=""
-MONGO_USER=""
-MONGO_PASSWORD=""
+MONGO_DATABASE=
+MONGO_USER=
+MONGO_PASSWORD=
 
-GITHUB_TOKEN=""
+# Github token needed to download weso dependencies
+# GITHUB_TOKEN=

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN curl -s https://bintray.com/sbt/rpm/rpm | \
     yum install sbt -y -q
 
 # ARGs - Override with: --build-arg [ARGUMENT]=[VALUE]
+# Values in .env will not be taken into account!
 # Permalink service creds.
 ARG MONGO_DATABASE=""
 ARG MONGO_USER=""
@@ -23,7 +24,7 @@ ARG MONGO_PASSWORD=""
 ARG GITHUB_TOKEN=""
 # Port for the app to run
 ENV PORT=80
-# Add rdfshape output dir to path
+# Add rdfshape output-directory to path
 ENV PATH /app/target/universal/stage/bin:$PATH
 
 # Copy all application files and trigger build


### PR DESCRIPTION
Environment variables defined in .env are non-existant by default instead of empty strings.
Vars in .env do not override arguments provided to docker build/gh-actions anymore.