### PR TITLE
GitHub action for automated builds/publishments

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,0 +1,36 @@
+name: Publish Docker image
+on:
+  # Manual trigger
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Container Registry
+    if: ${{ github.repository_owner == 'weso' }} # Do not run in forks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push to GitHub Container Registry
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/weso/rdfshape-api:${{ github.sha }}
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN ["sbt", "Universal / packageBin"]
 
 ## Prod environment.
 FROM openjdk:12 as prod
+LABEL org.opencontainers.image.source="https://github.com/weso/rdfshape"
 WORKDIR /app
 
 # Copy zip with universal executable


### PR DESCRIPTION
Created an automated workflow that builds and pushes Docker images of rdfshape-api on pushes to the main repository's branch. New images are tagged with the hash of the commit that creates them.

See published images: https://github.com/orgs/weso/packages/container/package/rdfshape-api

Related: weso/rdfshape#239